### PR TITLE
Add prism's ability to import ftb modpacks and remove technic footnote

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -579,4 +579,4 @@ Note: This list is maintained mostly by me and random contributions. Data will i
 ### Source code and licenses
 #### 1. MultiMC is proprietary but a debranded MS-PL licensed version which lacks many keys MultiMC uses is available on GitHub
 #### 2. GDLauncher has a <a href="https://cla-assistant.io/gorilla-devs/GDLauncher">CLA</a>
-#### 4. Technic Launcher is GPL3, however the source repo has not been updated since 2014, meaning the current build is either completely seperate or a continuation of the public repo; which violates the GPL
+

--- a/readme.md
+++ b/readme.md
@@ -188,7 +188,7 @@ Note: This list is maintained mostly by me and random contributions. Data will i
     <tr>
         <td>FTB Modpacks</td>
         <td>❌No</td>
-        <td>❌No</td>
+        <td>🟠Importing from the FTB Launcher is supported</td>
         <td>❌No</td>
         <td>❌No</td>
         <td>❌No</td>

--- a/readme.md
+++ b/readme.md
@@ -188,7 +188,7 @@ Note: This list is maintained mostly by me and random contributions. Data will i
     <tr>
         <td>FTB Modpacks</td>
         <td>❌No</td>
-        <td>🟠Importing from the FTB Launcher is supported</td>
+        <td>🟠Import from FTB Launcher</td>
         <td>❌No</td>
         <td>❌No</td>
         <td>❌No</td>


### PR DESCRIPTION
This pull request adds info about the ability for Prism to import FTB modpacks. Previously, FTB packs were not supported by prism, but now it is possible. Additionally, the information about Technic Launcher has been removed from the documentation since they are publishing to https://github.com/TechnicPack/LauncherV3